### PR TITLE
Fix incorrect class reference in README (#1871)

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ dev_dependencies:
 
  ```dart     
 @AutoRouterConfig()      
-class AppRouter extends $AppRouter {      
+class AppRouter extends _$AppRouter {      
     
   @override      
   List<AutoRoute> get routes => [      


### PR DESCRIPTION
This pull request updates the README documentation to use the correct generated class name _$AppRouter in the @AutoRouterConfig annotation example. This change addresses issue #1871.